### PR TITLE
some nav refactor

### DIFF
--- a/client/.flowconfig
+++ b/client/.flowconfig
@@ -1,4 +1,5 @@
 [ignore]
+./node_modules/
 
 [include]
 

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,6 @@
     "react-moment": "^0.7.6",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.3.1",
-    "react-router-redux": "^5.0.0-alpha.9",
     "react-scripts": "1.1.4",
     "react-swipeable-views": "^0.12.14",
     "redux": "^4.0.0",

--- a/client/src/components/navbar/TempDrawerNav.js
+++ b/client/src/components/navbar/TempDrawerNav.js
@@ -16,6 +16,8 @@ import Button from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
 import MenuIcon from '@material-ui/icons/Menu';
 
+import TopLink from './TopLink';
+
 const drawerWidth = 240;
 
 const styles = theme => ({
@@ -73,7 +75,6 @@ class TempDrawerNav extends React.Component<Props, State> {
     const { 
         classes, 
         drawerItems,
-        children,
         appTitle,
         user,
     } = this.props;
@@ -104,10 +105,11 @@ class TempDrawerNav extends React.Component<Props, State> {
               color="inherit" 
               className={classes.flex}
               noWrap>
-              <Link to={`/`} style={{textDecoration: 'none', color: '#FFF'}}>
+              <Link to={"/"} style={{textDecoration: 'none', color: '#FFF'}}>
                 {appTitle}
               </Link>
             </Typography>
+            <TopLink />
             {
               user ? 
               <Typography 
@@ -117,7 +119,7 @@ class TempDrawerNav extends React.Component<Props, State> {
                 {user}
               </Typography> :
               <Button color="inherit">
-                <Link to={`/auth`} style={{ textDecoration: 'none', color: '#FFF'}}>
+                <Link to={"/auth"} style={{ textDecoration: 'none', color: '#FFF'}}>
                   Login
                 </Link>
               </Button>
@@ -139,13 +141,15 @@ class TempDrawerNav extends React.Component<Props, State> {
             {drawer}
           </div>
         </SwipeableDrawer>
-        <main className={classes.content}>
+        {/* <main className={classes.content}>
           <div className={classes.toolbar} />
           {children}
-        </main>
+        </main> */}
       </div>
     );
   }
 }
+
+
 
 export default withStyles(styles, { withTheme: true })(TempDrawerNav);

--- a/client/src/components/navbar/TopLink.js
+++ b/client/src/components/navbar/TopLink.js
@@ -1,0 +1,14 @@
+// @flow
+import React from 'react';
+
+type Props = {
+
+};
+
+const TopLink = (props: Props) => {
+    return (
+        <div> hi</div>
+    )
+};
+
+export default TopLink

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -24,14 +24,6 @@ const styles = theme => ({
   },
 });
 
-const Routes = (
-  <Switch>
-    <Route exact component={HomePage} path='/' />
-    <Route exact component={Authentication} path='/auth' />
-    <Route component={NotFound} />
-  </Switch>
-);
-
 class App extends Component {
 
   componentWillMount() {
@@ -41,18 +33,17 @@ class App extends Component {
   }
 
   render() {
-    // const {classes, user} = this.props;
     return (
-      <div>
-      <NavBar 
-        children={
-          <Grid container spacing={24} direction="column">
-            <Snackbar />
-            {Routes}
-          </Grid>
-        }
-      />
-    </div>
+      <NavBar>
+        <Snackbar />
+        <Grid container spacing={24} direction="column">
+          <Switch>
+            <Route exact component={HomePage} path='/home' />
+            <Route exact component={Authentication} path='/auth' />
+            <Route component={NotFound} />
+          </Switch>
+        </Grid>
+      </NavBar>
     );
   }
 }

--- a/client/src/containers/Authentication.js
+++ b/client/src/containers/Authentication.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
+import { Redirect } from 'react-router-dom'
 
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
@@ -21,7 +22,8 @@ type Props = {
     },
 };
 
-type State = {};
+type State = {
+};
 
 const styles = theme => ({
     textField: {
@@ -33,6 +35,10 @@ const styles = theme => ({
   });
 
 class Authentication extends Component<Props, State> {
+    initialState = {
+        loggedIn: false
+    }
+
     handleLogin = (username, password) => {
         if (password.length < 6) {
             this.props.showNotification('Password must be at least 6 characters', 'error')
@@ -59,8 +65,12 @@ class Authentication extends Component<Props, State> {
     render() {
         const {
             classes,
-            auth: { fetching }
+            auth: { fetching, loggedIn }
         } = this.props;
+        if (loggedIn) {
+            return <Redirect to='/' />
+        }
+
         return (
                 <Grid container spacing={16} justify="center">
                     <Grid item xs={12} sm={8} md={6} lg={3} >

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,20 +1,18 @@
 import React from 'react';
 import { render } from 'react-dom';
 
-import { 
-    ConnectedRouter,
-} from 'react-router-redux';
+import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from "react-redux";
 import './index.css';
 
 import App from './containers/App';
-import { store, history } from './redux/store';
+import { store } from './redux/store';
 
 render(
     <Provider store={store}>
-        <ConnectedRouter history={history}>
+        <Router>
             <App />
-        </ConnectedRouter>
+        </Router>
     </Provider>,
     document.getElementById('root')
 );

--- a/client/src/redux/reducers/index.js
+++ b/client/src/redux/reducers/index.js
@@ -4,7 +4,6 @@ import todaysMatches from './todays_matches';
 import matches from './matches';
 import auth from './auth';
 import notification from './notification';
-import { routerReducer } from 'react-router-redux'
 
 
 export default combineReducers({
@@ -12,5 +11,4 @@ export default combineReducers({
   matches,
   auth,
   notification,
-  router: routerReducer,
 })

--- a/client/src/redux/sagas/auth.js
+++ b/client/src/redux/sagas/auth.js
@@ -1,7 +1,5 @@
-// @flow
 import axios from 'axios';
 import { call, put } from 'redux-saga/effects';
-import { push } from 'react-router-redux';
 
 import * as actions from '../actions';
 
@@ -14,7 +12,6 @@ const loginSaga = function* ({username, password}) {
         const response = yield call(authEndpoint, 'login', username, password);
         yield put(actions.loginSuccess({username: response.data.username}))
         yield put(actions.showNotification(`Welcome back, ${username}!`, 'success'));
-        yield put(push('/'));
     } 
     catch (error) {
         yield put(actions.showNotification('Invalid username or password', 'error'))
@@ -27,7 +24,6 @@ const registerSaga = function* ({username, password}) {
         const response = yield call(authEndpoint, 'register', username, password);
         yield put(actions.registerSuccess(response.data.username))
         yield put(actions.showNotification(`Welcome ${username}!`, 'success'));
-        yield put(push('/'));
     } 
     catch (error) {
         yield put(actions.showNotification('Invalid username or password', 'error'))

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -4,13 +4,9 @@ import createSagaMiddleware from "redux-saga";
 import rootReducer from "./reducers";
 import rootSaga from "./sagas";
 
-import { routerMiddleware } from 'react-router-redux';
-import createHistory from "history/createBrowserHistory";
-
 // create the saga middleware
 const sagaMiddleware = createSagaMiddleware();
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-const history = createHistory();
 
 // create a redux store with our reducer above and middleware
 let store = createStore(
@@ -18,7 +14,6 @@ let store = createStore(
   composeEnhancers(
     applyMiddleware(
       sagaMiddleware,
-      routerMiddleware(history),
     ),
   ),
 );
@@ -28,5 +23,4 @@ sagaMiddleware.run(rootSaga);
 
 export {
   store,
-  history,
 };

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -1,0 +1,1 @@
+import {createMuiTheme } from '@material-ui/core/styles';

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5960,15 +5960,7 @@ react-router-dom@^4.3.1:
     react-router "^4.3.1"
     warning "^4.0.1"
 
-react-router-redux@^5.0.0-alpha.9:
-  version "5.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-5.0.0-alpha.9.tgz#825431516e0e6f1fd93b8807f6bd595e23ec3d10"
-  dependencies:
-    history "^4.7.2"
-    prop-types "^15.6.0"
-    react-router "^4.2.0"
-
-react-router@^4.2.0, react-router@^4.3.1:
+react-router@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"
   dependencies:


### PR DESCRIPTION
Removes the integration on `react-router-redux`. This was used to change nav routes during sagas, but opting for a declarative approach since the above library is not maintained anymore.